### PR TITLE
refactor: add convention plugins to apply common build configuration

### DIFF
--- a/rss-generator/app/build.gradle.kts
+++ b/rss-generator/app/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.spotless)
+    id("com.livefast.eattrash.jvm")
+    id("com.livefast.eattrash.spotless")
     application
 }
 
@@ -18,27 +18,10 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
-
 application {
     mainClass = "com.livefast.eattrash.rssgenerator.MainKt"
 }
 
 tasks.named<Test>("test") {
     useJUnitPlatform()
-}
-
-spotless {
-    kotlin {
-        target("**/*.kt")
-        ktlint(libs.versions.ktlint.get())
-    }
-    kotlinGradle {
-        target("*.gradle.kts")
-        ktlint(libs.versions.ktlint.get())
-    }
 }

--- a/rss-generator/build-logic/conventions/build.gradle.kts
+++ b/rss-generator/build-logic/conventions/build.gradle.kts
@@ -9,5 +9,9 @@ dependencies {
 
 gradlePlugin {
     plugins {
+        register("jvmPlugin") {
+            id = "com.livefast.eattrash.jvm"
+            implementationClass = "plugins.JvmPlugin"
+        }
     }
 }

--- a/rss-generator/build-logic/conventions/build.gradle.kts
+++ b/rss-generator/build-logic/conventions/build.gradle.kts
@@ -13,5 +13,9 @@ gradlePlugin {
             id = "com.livefast.eattrash.jvm"
             implementationClass = "plugins.JvmPlugin"
         }
+        register("spotlessPlugin") {
+            id = "com.livefast.eattrash.spotless"
+            implementationClass = "plugins.SpotlessPlugin"
+        }
     }
 }

--- a/rss-generator/build-logic/conventions/build.gradle.kts
+++ b/rss-generator/build-logic/conventions/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    compileOnly(libs.kotlin.gradlePlugin)
+    compileOnly(libs.spotless.gradlePlugin)
+}
+
+gradlePlugin {
+    plugins {
+    }
+}

--- a/rss-generator/build-logic/conventions/src/main/kotlin/plugins/JvmPlugin.kt
+++ b/rss-generator/build-logic/conventions/src/main/kotlin/plugins/JvmPlugin.kt
@@ -1,0 +1,28 @@
+package plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import utils.libs
+import utils.pluginId
+
+/**
+ * Convention plugin to apply common JVM configuration.
+ */
+class JvmPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply(libs.findPlugin("kotlin-jvm").pluginId)
+            }
+            extensions.configure(JavaPluginExtension::class.java) {
+                toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+            }
+            extensions.configure(KotlinProjectExtension::class.java) {
+                jvmToolchain(21)
+            }
+        }
+    }
+}

--- a/rss-generator/build-logic/conventions/src/main/kotlin/plugins/SpotlessPlugin.kt
+++ b/rss-generator/build-logic/conventions/src/main/kotlin/plugins/SpotlessPlugin.kt
@@ -1,0 +1,33 @@
+package plugins
+
+import com.diffplug.gradle.spotless.SpotlessExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import utils.libs
+import utils.pluginId
+import utils.version
+
+/**
+ * Convention plugin to apply common Spotless and Ktlint configuration.
+ */
+class SpotlessPlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit =
+        with(target) {
+            with(pluginManager) {
+                apply(libs.findPlugin("spotless").pluginId)
+            }
+            extensions.configure(SpotlessExtension::class.java) {
+                kotlin {
+                    target("**/*.kt")
+                    targetExclude("**/build/**/*.kt")
+                    ktlint(libs.findVersion("ktlint").version)
+                    trimTrailingWhitespace()
+                    endWithNewline()
+                }
+                kotlinGradle {
+                    target("*.gradle.kts")
+                    ktlint(libs.findVersion("ktlint").version)
+                }
+            }
+        }
+}

--- a/rss-generator/build-logic/conventions/src/main/kotlin/utils/Utils.kt
+++ b/rss-generator/build-logic/conventions/src/main/kotlin/utils/Utils.kt
@@ -1,0 +1,18 @@
+package utils
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.artifacts.VersionConstraint
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.plugin.use.PluginDependency
+import java.util.Optional
+
+internal val Project.libs get() = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+internal val Optional<Provider<PluginDependency>>.pluginId get() = get().get().pluginId
+
+internal val Optional<VersionConstraint>.version get() = get().requiredVersion
+
+internal val Optional<Provider<MinimalExternalModuleDependency>>.dependency get() = get().get()

--- a/rss-generator/build-logic/settings.gradle.kts
+++ b/rss-generator/build-logic/settings.gradle.kts
@@ -1,0 +1,24 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
+include(":conventions")

--- a/rss-generator/core/data/build.gradle.kts
+++ b/rss-generator/core/data/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
+    id("com.livefast.eattrash.jvm")
+    id("com.livefast.eattrash.spotless")
     alias(libs.plugins.kotlinx.serialization)
-    alias(libs.plugins.spotless)
 }
 
 dependencies {
@@ -11,21 +11,4 @@ dependencies {
 
     implementation(project(":core:model"))
     implementation(project(":core:utils"))
-}
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
-
-spotless {
-    kotlin {
-        target("**/*.kt")
-        ktlint(libs.versions.ktlint.get())
-    }
-    kotlinGradle {
-        target("*.gradle.kts")
-        ktlint(libs.versions.ktlint.get())
-    }
 }

--- a/rss-generator/core/model/build.gradle.kts
+++ b/rss-generator/core/model/build.gradle.kts
@@ -1,21 +1,4 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.spotless)
-}
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
-
-spotless {
-    kotlin {
-        target("**/*.kt")
-        ktlint(libs.versions.ktlint.get())
-    }
-    kotlinGradle {
-        target("*.gradle.kts")
-        ktlint(libs.versions.ktlint.get())
-    }
+    id("com.livefast.eattrash.jvm")
+    id("com.livefast.eattrash.spotless")
 }

--- a/rss-generator/core/utils/build.gradle.kts
+++ b/rss-generator/core/utils/build.gradle.kts
@@ -1,26 +1,9 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.spotless)
+    id("com.livefast.eattrash.jvm")
+    id("com.livefast.eattrash.spotless")
 }
 
 dependencies {
     implementation(platform(libs.koin.bom))
     implementation(libs.koin.core)
-}
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
-
-spotless {
-    kotlin {
-        target("**/*.kt")
-        ktlint(libs.versions.ktlint.get())
-    }
-    kotlinGradle {
-        target("*.gradle.kts")
-        ktlint(libs.versions.ktlint.get())
-    }
 }

--- a/rss-generator/domain/build.gradle.kts
+++ b/rss-generator/domain/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.spotless)
+    id("com.livefast.eattrash.jvm")
+    id("com.livefast.eattrash.spotless")
 }
 
 dependencies {
@@ -10,21 +10,4 @@ dependencies {
 
     implementation(project(":core:model"))
     implementation(project(":core:utils"))
-}
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
-
-spotless {
-    kotlin {
-        target("**/*.kt")
-        ktlint(libs.versions.ktlint.get())
-    }
-    kotlinGradle {
-        target("*.gradle.kts")
-        ktlint(libs.versions.ktlint.get())
-    }
 }

--- a/rss-generator/gradle/libs.versions.toml
+++ b/rss-generator/gradle/libs.versions.toml
@@ -20,6 +20,9 @@ kotlin-xml-builder = { module = "org.redundent:kotlin-xml-builder", version.ref 
 
 yamlkt = { module = "net.mamoe.yamlkt:yamlkt", version.ref = "yamlkt" }
 
+kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+spotless-gradlePlugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
+
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/rss-generator/settings.gradle.kts
+++ b/rss-generator/settings.gradle.kts
@@ -13,6 +13,8 @@ dependencyResolutionManagement {
     }
 }
 
+includeBuild("build-logic")
+
 include(":app")
 
 include(":core:model")


### PR DESCRIPTION
Even if rss-generator is a small project, I really hate repeating myself. After modularizing it in #21, there were repeated build logic scattered in all Gradle scripts. This PR introduces a couple of convention plugins to avoid repetitions.